### PR TITLE
Double cookie fix

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package nosurf

--- a/handler.go
+++ b/handler.go
@@ -217,7 +217,7 @@ func (h *CSRFHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Finally, we check the token itself.
 	sentToken := extractToken(r)
 
-	if !verifyToken(realTokens[0], sentToken) {
+	if len(realTokens) != 1 || !verifyToken(realTokens[0], sentToken) {
 		ctxSetReason(r, ErrBadToken)
 		h.handleFailure(w, r)
 		return

--- a/handler_go17.go
+++ b/handler_go17.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package nosurf

--- a/handler_go17_test.go
+++ b/handler_go17_test.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package nosurf


### PR DESCRIPTION
Resolves an issue where, when multiple CSRF cookies are set, a random one would be used to verify the CSRF token. Now, regardless of how many conflicting CSRF cookies exist, if one of them is valid, the request will pass and clean up the cookie store.

See ory/kratos#2121
See ory-corp/cloud#1786